### PR TITLE
fix : downgrade  r version to 4.04 instead of 4.1

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Setup R
         uses: r-lib/actions/setup-r@master
+        with:
+          r-version: '4.0.4'
 
       - name: Install pandoc
         run: |


### PR DESCRIPTION
L'installation de sf ne se passe plus bien depuis qu'ils ont passé il y a 2 jours à la version 4.1
En 4.0.4 ca a l'air de fonctionner.
