### PR TITLE
Maj image de base onyxia

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-ARG R_VERSION=4.0.4
+ARG R_VERSION=4.2.1
 
-FROM inseefrlab/rstudio:${R_VERSION}
-
+FROM inseefrlab/onyxia-rstudio:r${R_VERSION}
 ENV RENV_VERSION 0.14.0
 RUN apt-get update && apt-get install -y cargo
 RUN R -e "install.packages('remotes', repos = c(CRAN = 'https://cloud.r-project.org'))"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG R_VERSION=4.2.1
 
 FROM inseefrlab/onyxia-rstudio:r${R_VERSION}
-ENV RENV_VERSION 0.14.0
+ENV RENV_VERSION 0.16.0
 RUN apt-get update && apt-get install -y cargo
 RUN R -e "install.packages('remotes', repos = c(CRAN = 'https://cloud.r-project.org'))"
 RUN R -e "remotes::install_github('rstudio/renv@${RENV_VERSION}')"


### PR DESCRIPTION
Avec la mise à jour de l'API d'onyxia, il faut mettre à jour l'image de base pour construire les images docker.
Il n'y a pas d'image avec la version de R en 4.0.4 donc j'en profite pour mettre à jour la version de R.